### PR TITLE
test(corpus): add report regression tests for §4.1-4.8

### DIFF
--- a/test/corpus/block_comments.txt
+++ b/test/corpus/block_comments.txt
@@ -1,0 +1,102 @@
+// Regression set: block comments (/* ... */) at file start, between statements, multi-line, and inline inside expressions.
+// All tests must pass on the current grammar.
+
+================================================================================
+File-leading block comment
+================================================================================
+
+/* hello world */
+function F() return 1; end function;
+
+_ := F();
+
+--------------------------------------------------------------------------------
+
+(program
+  (comment)
+  (expression_statement
+    (function_definition
+      name: (identifier)
+      parameters: (parameters)
+      body: (block
+        (return_statement
+          (integer)))))
+  (assignment
+    left: (anonymous_identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list))))
+
+================================================================================
+Multi-line block comment
+================================================================================
+
+/* hello
+   spans
+   multiple lines */
+x := 1;
+
+--------------------------------------------------------------------------------
+
+(program
+  (comment)
+  (assignment
+    left: (identifier)
+    right: (integer)))
+
+================================================================================
+Block comment between statements
+================================================================================
+
+x := 1;
+/* a note */
+y := 2;
+/* mid */ z := 3;
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (comment)
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (comment)
+  (assignment
+    left: (identifier)
+    right: (integer)))
+
+================================================================================
+Triple-asterisk header comment
+================================================================================
+
+/*** doc header
+ *  with leading asterisks
+ */
+x := 1;
+
+--------------------------------------------------------------------------------
+
+(program
+  (comment)
+  (assignment
+    left: (identifier)
+    right: (integer)))
+
+================================================================================
+Block comment inline inside an expression
+================================================================================
+
+x := 1 + /* note */ 2;
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (binary_operator
+      left: (integer)
+      (comment)
+      right: (integer))))

--- a/test/corpus/comprehensions_advanced.txt
+++ b/test/corpus/comprehensions_advanced.txt
@@ -1,0 +1,221 @@
+// Regression set: sequence/set comprehensions and seq_slice constructs (backquote-attribute universe, cat-prefixed, descending range, multi-iter+filter, by-step slice).
+// All tests must pass on the current grammar.
+
+================================================================================
+Comprehension with backquote-attribute universe
+================================================================================
+
+R := rec< recformat<L, H> | L := [], H := [1, 2] >;
+_ := [ R`L cat [b] : b in R`H ];
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (constructor
+      name: (identifier)
+      (recformat_constructor
+        (identifier)
+        (identifier))
+      (constructor_elements
+        (simple_assignment
+          name: (identifier)
+          value: (seqenum))
+        (simple_assignment
+          name: (identifier)
+          value: (seqenum
+            (integer)
+            (integer))))))
+  (assignment
+    left: (anonymous_identifier)
+    right: (seqenum
+      (binary_operator
+        left: (attribute
+          (identifier)
+          (identifier))
+        right: (seqenum
+          (identifier)))
+      (iter_vars
+        (iter_var
+          variable: (identifier)
+          (attribute
+            (identifier)
+            (identifier)))))))
+
+================================================================================
+Cat-prefixed comprehension
+================================================================================
+
+numones1 := 3;
+_ := &cat [[1] : i in [1..numones1] ];
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (assignment
+    left: (anonymous_identifier)
+    right: (reduct_operator
+      right: (seqenum
+        (seqenum
+          (integer))
+        (iter_vars
+          (iter_var
+            variable: (identifier)
+            (seqenum
+              (range
+                start: (integer)
+                end: (identifier)))))))))
+
+================================================================================
+Comprehension over descending range with by -1
+================================================================================
+
+N := 5;
+V := VectorSpace(Rationals(), N);
+pos := [V.i : i in [1..N]];
+_ := [ sub< V | pos[r] > : r in [N..1 by -1] ];
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (assignment
+    left: (identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (call
+          function: (identifier)
+          arguments: (argument_list))
+        argument: (identifier))))
+  (assignment
+    left: (identifier)
+    right: (seqenum
+      (binary_operator
+        left: (identifier)
+        right: (identifier))
+      (iter_vars
+        (iter_var
+          variable: (identifier)
+          (seqenum
+            (range
+              start: (integer)
+              end: (identifier)))))))
+  (assignment
+    left: (anonymous_identifier)
+    right: (seqenum
+      (constructor
+        name: (identifier)
+        (identifier)
+        (constructor_elements
+          (seq_slice
+            parent: (identifier)
+            (seqenum
+              (identifier)))))
+      (iter_vars
+        (iter_var
+          variable: (identifier)
+          (seqenum
+            (range
+              start: (identifier)
+              end: (integer)
+              by: (integer))))))))
+
+================================================================================
+Comprehension with multi-iter and condition
+================================================================================
+
+S := [1, 2, 3];
+T := [4, 5, 6];
+_ := [ x*y : x in S, y in T | x ne y ];
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (seqenum
+      (integer)
+      (integer)
+      (integer)))
+  (assignment
+    left: (identifier)
+    right: (seqenum
+      (integer)
+      (integer)
+      (integer)))
+  (assignment
+    left: (anonymous_identifier)
+    right: (seqenum
+      (binary_operator
+        left: (identifier)
+        right: (identifier))
+      (iter_vars
+        (iter_var
+          variable: (identifier)
+          (identifier))
+        (iter_var
+          variable: (identifier)
+          (identifier)))
+      condition: (binary_operator
+        left: (identifier)
+        right: (identifier)))))
+
+================================================================================
+Sequence-slice with by step
+================================================================================
+
+S := [1..10];
+_ := S[1..#S by 2];
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (seqenum
+      (range
+        start: (integer)
+        end: (integer))))
+  (assignment
+    left: (anonymous_identifier)
+    right: (seq_slice
+      parent: (identifier)
+      (seqenum
+        (range
+          start: (integer)
+          end: (unary_operator
+            right: (identifier))
+          by: (integer))))))
+
+================================================================================
+Sequence-slice plain range
+================================================================================
+
+S := [1..10];
+_ := S[1..#S];
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (seqenum
+      (range
+        start: (integer)
+        end: (integer))))
+  (assignment
+    left: (anonymous_identifier)
+    right: (seq_slice
+      parent: (identifier)
+      (seqenum
+        (range
+          start: (integer)
+          end: (unary_operator
+            right: (identifier)))))))

--- a/test/corpus/named_param_defaults.txt
+++ b/test/corpus/named_param_defaults.txt
@@ -1,0 +1,221 @@
+// Regression set: function/intrinsic parameter defaults declared after ':' (named/keyword args), at definition and call sites.
+// All tests must pass on the current grammar.
+
+================================================================================
+function with named-param default
+================================================================================
+
+function Foo(JI : models := true)
+    return JI;
+end function;
+
+_ := Foo(7);
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (function_definition
+      name: (identifier)
+      parameters: (parameters
+        (identifier)
+        (optional_parameter
+          name: (identifier)
+          value: (true)))
+      body: (block
+        (return_statement
+          (identifier)))))
+  (assignment
+    left: (anonymous_identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (integer)))))
+
+================================================================================
+function with multiple named-param defaults
+================================================================================
+
+function G(x, y, z : a := 1, b := 2)
+    return x + y + z + a + b;
+end function;
+
+_ := G(1, 2, 3 : a := 5);
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (function_definition
+      name: (identifier)
+      parameters: (parameters
+        (identifier)
+        (identifier)
+        (identifier)
+        (optional_parameter
+          name: (identifier)
+          value: (integer))
+        (optional_parameter
+          name: (identifier)
+          value: (integer)))
+      body: (block
+        (return_statement
+          (binary_operator
+            left: (binary_operator
+              left: (binary_operator
+                left: (binary_operator
+                  left: (identifier)
+                  right: (identifier))
+                right: (identifier))
+              right: (identifier))
+            right: (identifier))))))
+  (assignment
+    left: (anonymous_identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (integer)
+        argument: (integer)
+        argument: (integer)
+        (optional_argument
+          argument: (identifier)
+          default_value: (integer))))))
+
+================================================================================
+function with no-space before := in kwarg default
+================================================================================
+
+function H(x : k:= 7)
+    return x + k;
+end function;
+
+_ := H(1);
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (function_definition
+      name: (identifier)
+      parameters: (parameters
+        (identifier)
+        (optional_parameter
+          name: (identifier)
+          value: (integer)))
+      body: (block
+        (return_statement
+          (binary_operator
+            left: (identifier)
+            right: (identifier))))))
+  (assignment
+    left: (anonymous_identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (integer)))))
+
+================================================================================
+Anonymous function assigned with named-param defaults
+================================================================================
+
+F := function(x : max := true, Print := 0)
+    return x;
+end function;
+
+_ := F(7 : max := false, Print := 2);
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (function_definition
+      parameters: (parameters
+        (identifier)
+        (optional_parameter
+          name: (identifier)
+          value: (true))
+        (optional_parameter
+          name: (identifier)
+          value: (integer)))
+      body: (block
+        (return_statement
+          (identifier)))))
+  (assignment
+    left: (anonymous_identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (integer)
+        (optional_argument
+          argument: (identifier)
+          default_value: (false))
+        (optional_argument
+          argument: (identifier)
+          default_value: (integer))))))
+
+================================================================================
+Intrinsic with typed param and named-param default
+================================================================================
+
+intrinsic FooBar(M::Mtrx : check := true) -> Mtrx
+{Trivial intrinsic.}
+    return M;
+end intrinsic;
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (intrinsic_definition
+      name: (identifier)
+      parameters: (typed_identifier
+        (identifier)
+        (type
+          (identifier)))
+      parameters: (optional_parameter
+        name: (identifier)
+        value: (true))
+      return_type: (type
+        (identifier))
+      docstring: (doc_string)
+      body: (block
+        (return_statement
+          (identifier))))))
+
+================================================================================
+Inline one-line function with identifier-valued kwarg at call site
+================================================================================
+
+f := function(x : k := 0) return x + k; end function;
+step := 9;
+_ := f(2 : k := step);
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (function_definition
+      parameters: (parameters
+        (identifier)
+        (optional_parameter
+          name: (identifier)
+          value: (integer)))
+      body: (block
+        (return_statement
+          (binary_operator
+            left: (identifier)
+            right: (identifier))))))
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (assignment
+    left: (anonymous_identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (integer)
+        (optional_argument
+          argument: (identifier)
+          default_value: (identifier))))))

--- a/test/corpus/operator_adjacency.txt
+++ b/test/corpus/operator_adjacency.txt
@@ -1,0 +1,207 @@
+// Regression set: word-form binary operators (div, mod, cat, meet) parse correctly adjacent to parens/brackets without surrounding whitespace, and across line breaks.
+// All tests must pass on the current grammar.
+
+================================================================================
+div without space after closing paren
+================================================================================
+
+v := 7;
+_ := (v mod 4)div 2;
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (assignment
+    left: (anonymous_identifier)
+    right: (binary_operator
+      left: (parenthesized_expression
+        (binary_operator
+          left: (identifier)
+          right: (integer)))
+      right: (integer))))
+
+================================================================================
+div with space after closing paren
+================================================================================
+
+v := 7;
+_ := (v mod 4) div 2;
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (assignment
+    left: (anonymous_identifier)
+    right: (binary_operator
+      left: (parenthesized_expression
+        (binary_operator
+          left: (identifier)
+          right: (integer)))
+      right: (integer))))
+
+================================================================================
+mod adjacent to closing paren in nested expression
+================================================================================
+
+n := 30;
+_ := ((n-1)mod 26);
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (assignment
+    left: (anonymous_identifier)
+    right: (parenthesized_expression
+      (binary_operator
+        left: (parenthesized_expression
+          (binary_operator
+            left: (identifier)
+            right: (integer)))
+        right: (integer)))))
+
+================================================================================
+Comprehension mixing mod and div
+================================================================================
+
+n := 5;
+_ := [&cat [CodeToString(65 + ((j-1) mod 26)) : j in [1..n]] : i in [0..((n-1) div 26)]];
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (assignment
+    left: (anonymous_identifier)
+    right: (seqenum
+      (reduct_operator
+        right: (seqenum
+          (call
+            function: (identifier)
+            arguments: (argument_list
+              argument: (binary_operator
+                left: (integer)
+                right: (parenthesized_expression
+                  (binary_operator
+                    left: (parenthesized_expression
+                      (binary_operator
+                        left: (identifier)
+                        right: (integer)))
+                    right: (integer))))))
+          (iter_vars
+            (iter_var
+              variable: (identifier)
+              (seqenum
+                (range
+                  start: (integer)
+                  end: (identifier)))))))
+      (iter_vars
+        (iter_var
+          variable: (identifier)
+          (seqenum
+            (range
+              start: (integer)
+              end: (parenthesized_expression
+                (binary_operator
+                  left: (parenthesized_expression
+                    (binary_operator
+                      left: (identifier)
+                      right: (integer)))
+                  right: (integer))))))))))
+
+================================================================================
+div on its own line as continuation
+================================================================================
+
+x := 12;
+y := 4;
+_ := (x + y)
+    div (y + 1);
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (assignment
+    left: (anonymous_identifier)
+    right: (binary_operator
+      left: (parenthesized_expression
+        (binary_operator
+          left: (identifier)
+          right: (identifier)))
+      right: (parenthesized_expression
+        (binary_operator
+          left: (identifier)
+          right: (integer))))))
+
+================================================================================
+meet at end of line continuation
+================================================================================
+
+A := {1, 2, 3};
+B := {2, 3};
+C := {3, 4};
+_ := A meet
+     B meet
+     C;
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (set
+      (integer)
+      (integer)
+      (integer)))
+  (assignment
+    left: (identifier)
+    right: (set
+      (integer)
+      (integer)))
+  (assignment
+    left: (identifier)
+    right: (set
+      (integer)
+      (integer)))
+  (assignment
+    left: (anonymous_identifier)
+    right: (binary_operator
+      left: (binary_operator
+        left: (identifier)
+        right: (identifier))
+      right: (identifier))))
+
+================================================================================
+cat operator adjacent to closing bracket
+================================================================================
+
+_ := [1, 2]cat [3, 4];
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (anonymous_identifier)
+    right: (binary_operator
+      left: (seqenum
+        (integer)
+        (integer))
+      right: (seqenum
+        (integer)
+        (integer)))))

--- a/test/corpus/rep_as_identifier.txt
+++ b/test/corpus/rep_as_identifier.txt
@@ -1,0 +1,189 @@
+// Regression set: 'rep' as an ordinary identifier; the soft-keyword only triggers representative_of_set when followed by a set literal.
+// All tests must pass on the current grammar.
+
+================================================================================
+rep as assignment target
+================================================================================
+
+rep := true;
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (true)))
+
+================================================================================
+rep as assignment from function call
+================================================================================
+
+F := GF(7);
+rep := NonsquareRep(F);
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (integer))))
+  (assignment
+    left: (identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (identifier)))))
+
+================================================================================
+rep as function argument
+================================================================================
+
+rep := 7;
+_ := Type(rep);
+_ := Parent(rep);
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (assignment
+    left: (anonymous_identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (identifier))))
+  (assignment
+    left: (anonymous_identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (identifier)))))
+
+================================================================================
+rep as for-loop variable
+================================================================================
+
+reps := [1, 2, 3];
+for rep in reps do
+    _ := rep;
+end for;
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (seqenum
+      (integer)
+      (integer)
+      (integer)))
+  (for_statement
+    quantifier: (for_quantifier
+      (binary_operator
+        left: (identifier)
+        right: (identifier)))
+    body: (block
+      (assignment
+        left: (anonymous_identifier)
+        right: (identifier)))))
+
+================================================================================
+rep in local declaration
+================================================================================
+
+procedure P()
+    local E, G, rep, U;
+    rep := 0;
+end procedure;
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (procedure_definition
+      name: (identifier)
+      parameters: (parameters)
+      body: (block
+        (local_statement
+          (identifier)
+          (identifier)
+          (identifier)
+          (identifier))
+        (assignment
+          left: (identifier)
+          right: (integer))))))
+
+================================================================================
+rep as function-valued assignment
+================================================================================
+
+rep := func< x | x + 1 >;
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (constructor
+      name: (identifier)
+      (identifier)
+      (constructor_elements
+        (binary_operator
+          left: (identifier)
+          right: (integer))))))
+
+================================================================================
+rep used in a select expression
+================================================================================
+
+T := [1, 2, 3];
+rep := 4 * #T lt 100 select "Sparse" else "Dense";
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (seqenum
+      (integer)
+      (integer)
+      (integer)))
+  (assignment
+    left: (identifier)
+    right: (ternary_operator
+      conditional: (binary_operator
+        left: (binary_operator
+          left: (integer)
+          right: (unary_operator
+            right: (identifier)))
+        right: (integer))
+      then: (string)
+      else: (string))))
+
+================================================================================
+Positive: rep keyword extracts a representative from a set
+================================================================================
+
+x := rep {n : n in [1..5]};
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (representative_of_set
+      (identifier)
+      (set
+        (identifier)
+        (iter_vars
+          (iter_var
+            variable: (identifier)
+            (seqenum
+              (range
+                start: (integer)
+                end: (integer)))))))))

--- a/test/corpus/string_escapes.txt
+++ b/test/corpus/string_escapes.txt
@@ -1,0 +1,163 @@
+// Regression set: backslash escape sequences in strings (\n, \t, \r, \", \\) and printf-style format directives.
+// All tests must pass on the current grammar.
+
+================================================================================
+Bare top-level string with escape
+================================================================================
+
+"\nRegularModel: Not yet implemented for this number field.";
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (string)))
+
+================================================================================
+printf with newline only
+================================================================================
+
+printf "\n";
+
+--------------------------------------------------------------------------------
+
+(program
+  (print_statement
+    (string)))
+
+================================================================================
+print with multi-line escape sequences
+================================================================================
+
+print "\nThe right ideal is the null ideal. \n";
+
+--------------------------------------------------------------------------------
+
+(program
+  (print_statement
+    (string)))
+
+================================================================================
+vprintf with escape
+================================================================================
+
+SetVerbose("Hyperelliptic", 1);
+vprintf Hyperelliptic, 1 : "R1210 = 0\n";
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (string)
+        argument: (integer))))
+  (vprint_statement
+    flag: (identifier)
+    n: (integer)
+    (string)))
+
+================================================================================
+Escape sequences inside set literal
+================================================================================
+
+white := {" ", "\n", "\r", "\t"};
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (set
+      (string)
+      (string)
+      (string)
+      (string))))
+
+================================================================================
+error if with newline string
+================================================================================
+
+error if false, "\nBase field not finite\n";
+
+--------------------------------------------------------------------------------
+
+(program
+  (error_statement
+    condition: (false)
+    (string)))
+
+================================================================================
+Join with newline separator
+================================================================================
+
+S := ["a", "b"];
+_ := Join(S, "\n");
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (seqenum
+      (string)
+      (string)))
+  (assignment
+    left: (anonymous_identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (identifier)
+        argument: (string)))))
+
+================================================================================
+printf with format directive percent o
+================================================================================
+
+x := 1;
+printf "value %o\n", x;
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (print_statement
+    (string)
+    (identifier)))
+
+================================================================================
+printf with width format directive
+================================================================================
+
+x := 1;
+printf "%4o", x;
+printf "%-3o", x;
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (print_statement
+    (string)
+    (identifier))
+  (print_statement
+    (string)
+    (identifier)))
+
+================================================================================
+String with double backslash and escaped quote
+================================================================================
+
+x := "say \"hi\" then \\";
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (string)))

--- a/test/corpus/vtime_forms.txt
+++ b/test/corpus/vtime_forms.txt
@@ -1,0 +1,195 @@
+// Regression set: vtime statement (and sister 'time' statement) - same-line, multi-line body, multi-LHS, with keyword args.
+// All tests must pass on the current grammar.
+
+================================================================================
+vtime basic same-line form
+================================================================================
+
+SetVerbose("LLL", 0);
+_ := 0;
+vtime LLL, 2: m := Identity(MatrixAlgebra(Rationals(), 2));
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (string)
+        argument: (integer))))
+  (assignment
+    left: (anonymous_identifier)
+    right: (integer))
+  (vtime_statement
+    flag: (identifier)
+    n: (integer)
+    (assignment
+      left: (identifier)
+      right: (call
+        function: (identifier)
+        arguments: (argument_list
+          argument: (call
+            function: (identifier)
+            arguments: (argument_list
+              argument: (call
+                function: (identifier)
+                arguments: (argument_list))
+              argument: (integer))))))))
+
+================================================================================
+vtime with multi-LHS assignment and keyword arg
+================================================================================
+
+SetVerbose("RelLLL", 0);
+L := IdentityMatrix(Rationals(), 3);
+vtime RelLLL, 2: LL, T := LLL(L : Sort := false);
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (string)
+        argument: (integer))))
+  (assignment
+    left: (identifier)
+    right: (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (call
+          function: (identifier)
+          arguments: (argument_list))
+        argument: (integer))))
+  (vtime_statement
+    flag: (identifier)
+    n: (integer)
+    (assignment
+      left: (identifier)
+      left: (identifier)
+      right: (call
+        function: (identifier)
+        arguments: (argument_list
+          argument: (identifier)
+          (optional_argument
+            argument: (identifier)
+            default_value: (false)))))))
+
+================================================================================
+vtime statement on next line after colon
+================================================================================
+
+SetVerbose("SEA", 0);
+NaiveEulerFactor := func< x | x >;
+C := 1;
+vtime SEA, 4:
+    charpol := NaiveEulerFactor(C);
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (string)
+        argument: (integer))))
+  (assignment
+    left: (identifier)
+    right: (constructor
+      name: (identifier)
+      (identifier)
+      (constructor_elements
+        (identifier))))
+  (assignment
+    left: (identifier)
+    right: (integer))
+  (vtime_statement
+    flag: (identifier)
+    n: (integer)
+    (assignment
+      left: (identifier)
+      right: (call
+        function: (identifier)
+        arguments: (argument_list
+          argument: (identifier))))))
+
+================================================================================
+time statement (sister form, sanity)
+================================================================================
+
+f := func< x | x*x >;
+time _ := f(7);
+
+--------------------------------------------------------------------------------
+
+(program
+  (assignment
+    left: (identifier)
+    right: (constructor
+      name: (identifier)
+      (identifier)
+      (constructor_elements
+        (binary_operator
+          left: (identifier)
+          right: (identifier)))))
+  (time_statement
+    (assignment
+      left: (anonymous_identifier)
+      right: (call
+        function: (identifier)
+        arguments: (argument_list
+          argument: (integer))))))
+
+================================================================================
+vtime followed by call with multiple kwargs
+================================================================================
+
+SetVerbose("Groebner", 0);
+F := function(x : a := 1, b := 2) return x + a + b; end function;
+vtime Groebner, 1: y := F(3 : a := 5, b := 10);
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (call
+      function: (identifier)
+      arguments: (argument_list
+        argument: (string)
+        argument: (integer))))
+  (assignment
+    left: (identifier)
+    right: (function_definition
+      parameters: (parameters
+        (identifier)
+        (optional_parameter
+          name: (identifier)
+          value: (integer))
+        (optional_parameter
+          name: (identifier)
+          value: (integer)))
+      body: (block
+        (return_statement
+          (binary_operator
+            left: (binary_operator
+              left: (identifier)
+              right: (identifier))
+            right: (identifier))))))
+  (vtime_statement
+    flag: (identifier)
+    n: (integer)
+    (assignment
+      left: (identifier)
+      right: (call
+        function: (identifier)
+        arguments: (argument_list
+          argument: (integer)
+          (optional_argument
+            argument: (identifier)
+            default_value: (integer))
+          (optional_argument
+            argument: (identifier)
+            default_value: (integer)))))))


### PR DESCRIPTION
Lock in the parse-ability gains from recent grammar hardening as **per-section corpus regression tests**. None of the bugs covered here parse-fail today — the goal is to prevent silent regressions of constructs that used to break before commits like 1ac18ae, d8c6e75, 5f0625c, 81185cd, a064a8d, 70419ad, e0bf243, ccce73a, 3f08d08.

7 new files under `test/corpus/`, **47 tests**, all passing on the current grammar.

## Background

A recent audit of `magma-2.29-6/package/` (3465 `.m` files) showed:

| Metric | Pre-hardening (commit `a5beb85`) | Now (`7540c50`) |
| --- | ---: | ---: |
| Files audited | 3462 | 3465 |
| Files with parse `ERROR` | 1124 | 12 |
| % broken | **32.5 %** | **0.3 %** |
| Plus timeouts | — | 1 |

Of the 12 + 1 still failing today: 4 are due to mid-token `\<newline>` line continuations in auto-generated polynomial files (handled separately by Magma source fixes — out of scope here), 3 are real syntax bugs in the Magma source (also out of scope), and 6 are MATLAB/Octave benchmark scripts that happen to have a `.m` extension.

The bulk of the gains have no automated regression coverage in `test/corpus/` today. This PR closes that gap.

## Files added

| File | Coverage |
| --- | --- |
| `string_escapes.txt` | `\n`, `\t`, `\r`, `\"`, `\\` in strings; `printf`/`vprintf`/`error if`/bare-string contexts; format directives (`%o`, `%4o`, `%-3o`) |
| `comprehensions_advanced.txt` | Backquote-attribute universe, `&cat`-prefixed, descending range with `by -1`, multi-iter + filter, `seq_slice` with/without `by` step |
| `rep_as_identifier.txt` | `rep` as ordinary identifier in 7 positions (assignment LHS, function arg, loop var, local list, function-valued, select expression); plus one positive test that pins the soft-keyword still triggers `representative_of_set` |
| `operator_adjacency.txt` | Word operators `div`/`mod`/`cat`/`meet` parsing correctly when adjacent to `)`/`]` without whitespace, and at end/start of line |
| `vtime_forms.txt` | `vtime` same-line, multi-line body, multi-LHS, with keyword args; sister `time` statement |
| `named_param_defaults.txt` | Function/intrinsic parameter defaults via `:`; multi-default; no-space `:= `/`:=` variants; anonymous-function form; intrinsic with typed param; identifier-valued kwarg at call site |
| `block_comments.txt` | `/* … */` at file start, multi-line, between statements, inline inside expressions, triple-asterisk header style |

Each file's first line is a `//` comment summarizing the regression set's scope.